### PR TITLE
Feature/ganache compatibility

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,7 +1,7 @@
 require('dotenv').config()
 require('@nomiclabs/hardhat-ethers')
-require("@nomiclabs/hardhat-web3");
-require("@nomicfoundation/hardhat-chai-matchers");
+require('@nomiclabs/hardhat-web3')
+require('@nomicfoundation/hardhat-chai-matchers')
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
@@ -18,6 +18,17 @@ module.exports = {
         'Content-Type': 'application/json',
       },
       accounts: [process.env.DEPLOYER_PRIVATE_KEY],
+    },
+    hardhat: {
+      mining: {
+        auto: false,
+        interval: 1000,
+      },
+      accounts: [
+        {
+          privateKey: process.env.DEPLOYER_PRIVATE_KEY,
+          balance: "1000000000000000000",
+        }],
     },
   },
 }

--- a/test/ethers.js/ERC20.js
+++ b/test/ethers.js/ERC20.js
@@ -1,21 +1,19 @@
 require('chai').should()
 const { ethers } = require('hardhat')
 const deployContract = require('./utils/deployContract')
-const { getDeployerF0Address } = require('./utils/getDeployerAddresses')
-const { getDeployerF1Address } = require('../util/utils')
+const { getDeployerAddress } = require('./utils/getDeployerAddresses')
 
 const TOKEN_NAME = 'my_token'
 const TOKEN_SYMBOL = 'TKN'
 const TOKEN_INITIAL_SUPPLY = 1000
 
-let deployerF0Addr, deploymentTxHash, erc20Address
+let deployerAddr, deploymentTxHash, erc20Address
 
 describe('ERC20', function () {
   it('Should successfully deploy', async function () {
-    const deployerF1Addr = getDeployerF1Address()
-    deployerF0Addr = await getDeployerF0Address(deployerF1Addr)
+    deployerAddr = await getDeployerAddress()
     const erc20 = await deployContract('ERC20PresetFixedSupply',
-      TOKEN_NAME, TOKEN_SYMBOL, TOKEN_INITIAL_SUPPLY, deployerF0Addr)
+      TOKEN_NAME, TOKEN_SYMBOL, TOKEN_INITIAL_SUPPLY, deployerAddr)
 
     deploymentTxHash = erc20.deployTransaction.hash
 
@@ -44,7 +42,7 @@ describe('ERC20', function () {
   it('Should set the right initial supply', async function () {
     const ERC20 = await ethers.getContractAt('ERC20PresetFixedSupply',
       erc20Address)
-    const ownerBalance = await ERC20.balanceOf(deployerF0Addr)
+    const ownerBalance = await ERC20.balanceOf(deployerAddr)
 
     ownerBalance.should.be.equal(TOKEN_INITIAL_SUPPLY)
   })

--- a/test/ethers.js/SimpleCoin.js
+++ b/test/ethers.js/SimpleCoin.js
@@ -54,7 +54,7 @@ describe('SimpleCoin', function () {
         deploymentTxHash)
       simpleCoinAddress = txReceipt.contractAddress
 
-      rpcTests.testGetMinedTransactionReceipt(txReceipt)
+      rpcTests.testGetMinedTransactionReceipt(txReceipt, false)
     })
   it('Should find the transaction in block tx list', async function () {
     const blockByHash = await ethers.provider.getBlock(deploymentBlockHash)

--- a/test/ethers.js/SimpleCoin.js
+++ b/test/ethers.js/SimpleCoin.js
@@ -1,12 +1,12 @@
 require('dotenv').config()
 const { artifacts, ethers } = require('hardhat')
 const deployContract = require('./utils/deployContract')
-const { getDeployerF0Address } = require(
-  './utils/getDeployerAddresses')
+const { getDeployerAddress } = require('./utils/getDeployerAddresses')
 const rpcTests = require('../util/testRpcResponses')
-const { mappingStoragePositionFromKey, getDeployerF1Address } = require('../util/utils')
+const { mappingStoragePositionFromKey } = require(
+  '../util/utils')
 
-let deployerF0Addr, deploymentTxHash, deploymentBlockHash,
+let deployerAddr, deploymentTxHash, deploymentBlockHash,
   deploymentBlockNumber, simpleCoinAddress
 const otherAddress = '0xff000000000000000000000000000000deadbeef'
 
@@ -16,14 +16,13 @@ describe('SimpleCoin', function () {
 
     deploymentTxHash = simpleCoin.deployTransaction.hash
 
-    const f1Addr = getDeployerF1Address()
-    deployerF0Addr = await getDeployerF0Address(f1Addr)
+    deployerAddr = await getDeployerAddress()
   })
   it('Should access transaction details before it has been mined',
     async function () {
       const txByHash = await ethers.provider.getTransaction(deploymentTxHash)
 
-      rpcTests.testGetPendingTransactionByHash(txByHash, deployerF0Addr)
+      rpcTests.testGetPendingTransactionByHash(txByHash, deployerAddr)
     })
   it('Should access null transaction receipt before it has been mined',
     async function () {
@@ -47,7 +46,7 @@ describe('SimpleCoin', function () {
       deploymentBlockHash = blockHash
       deploymentBlockNumber = blockNumber
 
-      rpcTests.testGetMinedTransactionByHash(txByHash, deployerF0Addr)
+      rpcTests.testGetMinedTransactionByHash(txByHash, deployerAddr)
     })
   it('Should access transaction receipt after it has been mined',
     async function () {
@@ -61,24 +60,27 @@ describe('SimpleCoin', function () {
     const blockByHash = await ethers.provider.getBlock(deploymentBlockHash)
     const blockByNumber = await ethers.provider.getBlock(deploymentBlockNumber);
 
-    [blockByHash, blockByNumber].forEach(b => {rpcTests.testGetBlock(b, deploymentTxHash)})
+    [blockByHash, blockByNumber].forEach(
+      b => {rpcTests.testGetBlock(b, deploymentTxHash)})
     blockByHash.should.deep.equal(blockByNumber)
   })
   it('Should get block tx count', async function () {
     const blockTxCountByHash = await ethers.provider.send(
       'eth_getBlockTransactionCountByHash', [deploymentBlockHash])
-    const hexBlockNumber = ethers.utils.hexValue(ethers.BigNumber.from(deploymentBlockNumber));
+    const hexBlockNumber = ethers.utils.hexValue(
+      ethers.BigNumber.from(deploymentBlockNumber))
     const blockTxCountByNumber = await ethers.provider.send(
       'eth_getBlockTransactionCountByNumber',
       [hexBlockNumber]);
 
-    [blockTxCountByHash, blockTxCountByNumber].forEach(rpcTests.testGetBlockTxCount)
+    [blockTxCountByHash, blockTxCountByNumber].forEach(
+      rpcTests.testGetBlockTxCount)
     blockTxCountByHash.should.be.equal(blockTxCountByNumber)
   })
   it('Should interact with the contract using eth_call', async function () {
     const SimpleCoin = await ethers.getContractAt('SimpleCoin',
       simpleCoinAddress)
-    const deployerBalance = await SimpleCoin.getBalance(deployerF0Addr)
+    const deployerBalance = await SimpleCoin.getBalance(deployerAddr)
     const receiverBalance = await SimpleCoin.getBalance(otherAddress)
 
     rpcTests.testCall(deployerBalance, receiverBalance)
@@ -96,7 +98,7 @@ describe('SimpleCoin', function () {
     const SimpleCoin = await ethers.getContractAt('SimpleCoin',
       simpleCoinAddress)
 
-    let position = mappingStoragePositionFromKey(0, deployerF0Addr)
+    let position = mappingStoragePositionFromKey(0, deployerAddr)
     const storageAtDeployerBalance = await ethers.provider.getStorageAt(
       SimpleCoin.address,
       position)

--- a/test/ethers.js/SimpleCoin.js
+++ b/test/ethers.js/SimpleCoin.js
@@ -101,8 +101,6 @@ describe('SimpleCoin', function () {
       SimpleCoin.address,
       position)
 
-    storageAtDeployerBalance.should.be.equal(10000)
-
     position = mappingStoragePositionFromKey(0, otherAddress)
     const storageAtOtherBalance = await ethers.provider.getStorageAt(
       SimpleCoin.address,

--- a/test/ethers.js/SimpleCoin.js
+++ b/test/ethers.js/SimpleCoin.js
@@ -67,9 +67,10 @@ describe('SimpleCoin', function () {
   it('Should get block tx count', async function () {
     const blockTxCountByHash = await ethers.provider.send(
       'eth_getBlockTransactionCountByHash', [deploymentBlockHash])
+    const hexBlockNumber = ethers.utils.hexValue(ethers.BigNumber.from(deploymentBlockNumber));
     const blockTxCountByNumber = await ethers.provider.send(
       'eth_getBlockTransactionCountByNumber',
-      [ethers.utils.hexlify(deploymentBlockNumber)]);
+      [hexBlockNumber]);
 
     [blockTxCountByHash, blockTxCountByNumber].forEach(rpcTests.testGetBlockTxCount)
     blockTxCountByHash.should.be.equal(blockTxCountByNumber)

--- a/test/ethers.js/utils/deployContract.js
+++ b/test/ethers.js/utils/deployContract.js
@@ -1,22 +1,27 @@
 const { ethers } = require('hardhat')
-const { getDeployerF1Address } = require('../../util/utils')
+const { getDeployerF1Address, isFilecoinNetwork } = require('../../util/utils')
 
 const deployContract = async (contractName, ...args) => {
-  const f1Addr = getDeployerF1Address()
+  const isFilecoin = await isFilecoinNetwork()
 
-  const maxPriorityFeePerGas = await ethers.provider.send(
-    'eth_maxPriorityFeePerGas', [])
-  const nonce = await ethers.provider.send('Filecoin.MpoolGetNonce',
-    [f1Addr])
+  let options
+  if (isFilecoin) {
+    const f1Addr = getDeployerF1Address()
+    const nonce = await ethers.provider.send('Filecoin.MpoolGetNonce',
+      [f1Addr])
+    const maxPriorityFeePerGas = await ethers.provider.send(
+      'eth_maxPriorityFeePerGas', [])
+    options = { nonce, maxPriorityFeePerGas, gasLimit: 1000000000 }
+  } else {
+    const [ethDeployer] = await ethers.getSigners()
+    const nonce = await ethers.provider.getTransactionCount(ethDeployer.address)
+    options = { nonce }
+  }
 
   // create a contract factory
   const Contract = await ethers.getContractFactory(contractName)
   // send a deployment transaction, without waiting for the transaction to be mined
-  return await Contract.deploy(...args, {
-    gasLimit: 1000000000,
-    maxPriorityFeePerGas,
-    nonce,
-  })
+  return await Contract.deploy(...args, options)
 }
 
 module.exports = deployContract

--- a/test/ethers.js/utils/getDeployerAddresses.js
+++ b/test/ethers.js/utils/getDeployerAddresses.js
@@ -1,5 +1,15 @@
 const { ethers } = require('hardhat')
-const { actorIdToF0Address } = require('../../util/utils')
+const { actorIdToF0Address, isFilecoinNetwork, getDeployerF1Address } = require('../../util/utils')
+
+const getDeployerAddress = async () => {
+  if (await isFilecoinNetwork()) {
+    const deployerF1Addr = getDeployerF1Address()
+    return getDeployerF0Address(deployerF1Addr)
+  } else {
+    const [ethDeployer] = await ethers.getSigners();
+    return ethDeployer.address
+  }
+}
 
 const getDeployerF0Address = async (f1Addr) => {
   try {
@@ -15,5 +25,6 @@ const getDeployerF0Address = async (f1Addr) => {
 }
 
 module.exports = {
+  getDeployerAddress,
   getDeployerF0Address,
 }

--- a/test/util/testRpcResponses.js
+++ b/test/util/testRpcResponses.js
@@ -73,7 +73,7 @@ const testGetBlock = (block, deploymentTxHash) => {
     'uncles',
   )
   block.gasUsed.should.be.gt(0)
-  block.transactions.length.should.not.be.empty
+  block.transactions.should.not.be.empty
   block.transactions.should.contain(deploymentTxHash)
 }
 

--- a/test/util/testRpcResponses.js
+++ b/test/util/testRpcResponses.js
@@ -34,7 +34,7 @@ const testGetMinedTransactionByHash = (txByHash, deployerF0Addr) => {
   should.not.exist(txByHash.to)
 }
 
-const testGetMinedTransactionReceipt = (txReceipt) => {
+const testGetMinedTransactionReceipt = (txReceipt, isWeb3Js) => {
   txReceipt.should.contain.keys(
     'blockHash',
     'blockNumber',
@@ -49,7 +49,11 @@ const testGetMinedTransactionReceipt = (txReceipt) => {
   )
   txReceipt.gasUsed.should.be.gt(0)
   txReceipt.cumulativeGasUsed.should.be.gte(txReceipt.gasUsed)
-  txReceipt.status.should.equal(1)
+  let { status } = txReceipt;
+  if (isWeb3Js) {
+    status = status ? 1 : 0
+  }
+  status.should.equal(1)
 }
 
 const testGetBlock = (block, deploymentTxHash) => {

--- a/test/util/testRpcResponses.js
+++ b/test/util/testRpcResponses.js
@@ -48,7 +48,7 @@ const testGetMinedTransactionReceipt = (txReceipt) => {
     'effectiveGasPrice',
   )
   txReceipt.gasUsed.should.be.gt(0)
-  txReceipt.cumulativeGasUsed.should.be.gt(txReceipt.gasUsed)
+  txReceipt.cumulativeGasUsed.should.be.gte(txReceipt.gasUsed)
   txReceipt.status.should.equal(1)
 }
 

--- a/test/util/testRpcResponses.js
+++ b/test/util/testRpcResponses.js
@@ -91,8 +91,8 @@ const testGetCode = (code, expectedCode) => {
 }
 
 const testGetStorageAt = (storageAtDeployerBalance, storageAtOtherBalance) => {
-  storageAtDeployerBalance.should.be.equal(10000)
-  storageAtOtherBalance.should.be.equal(0)
+  storageAtDeployerBalance.should.be.equal('0x0000000000000000000000000000000000000000000000000000000000002710')
+  storageAtOtherBalance.should.be.equal('0x0000000000000000000000000000000000000000000000000000000000000000')
 }
 
 module.exports = {

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -1,8 +1,18 @@
 require('dotenv').config()
 const fa = require('@glif/filecoin-address')
+const { ethers } = require('hardhat')
 const { utils, BigNumber, Wallet } = require('hardhat').ethers
 
 const DEPLOYER_PRIVATE_KEY = process.env.DEPLOYER_PRIVATE_KEY
+
+const isFilecoinNetwork = async () => {
+  try {
+    await ethers.provider.send('Filecoin.Version', [])
+    return true
+  } catch (e) {
+    return false
+  }
+}
 
 const getDeployerF1Address = () => {
   // use the deployer private key to compute the Filecoin f1 deployer address
@@ -18,7 +28,6 @@ const actorIdToF0Address = (actorIdStr) => {
 }
 
 const mappingStoragePositionFromKey = (mapPosition, mapKey) => {
-
   let key = utils.hexConcat([
     utils.hexZeroPad(mapKey, 32),
     utils.hexZeroPad(BigNumber.from(mapPosition).toHexString(), 32),
@@ -27,6 +36,7 @@ const mappingStoragePositionFromKey = (mapPosition, mapKey) => {
 }
 
 module.exports = {
+  isFilecoinNetwork,
   getDeployerF1Address,
   actorIdToF0Address,
   mappingStoragePositionFromKey,

--- a/test/web3.js/ERC20.js
+++ b/test/web3.js/ERC20.js
@@ -16,9 +16,7 @@ describe('ERC20', function () {
     const { contract } = await deployContract('ERC20PresetFixedSupply',
       TOKEN_NAME, TOKEN_SYMBOL, TOKEN_INITIAL_SUPPLY, deployerF0Addr)
 
-    erc20 = contract
-
-    await erc20
+    erc20 = await contract
   })
   it('Should set the right name', async function () {
     const name = await erc20.methods.name().call()

--- a/test/web3.js/ERC20.js
+++ b/test/web3.js/ERC20.js
@@ -1,20 +1,18 @@
 require('chai').should()
 const deployContract = require('./utils/deployContract')
-const { getDeployerF1Address } = require('../util/utils')
-const { getDeployerF0Address } = require('./utils/getDeployerAddresses')
+const { getDeployerAddress } = require('./utils/getDeployerAddresses')
 
 const TOKEN_NAME = 'my_token'
 const TOKEN_SYMBOL = 'TKN'
 const TOKEN_INITIAL_SUPPLY = 1000
 
-let deployerF0Addr, erc20
+let deployerAddr, erc20
 
 describe('ERC20', function () {
   it('Should successfully deploy', async function () {
-    const deployerF1Addr = getDeployerF1Address()
-    deployerF0Addr = await getDeployerF0Address(deployerF1Addr)
+    deployerAddr = await getDeployerAddress()
     const { contract } = await deployContract('ERC20PresetFixedSupply',
-      TOKEN_NAME, TOKEN_SYMBOL, TOKEN_INITIAL_SUPPLY, deployerF0Addr)
+      TOKEN_NAME, TOKEN_SYMBOL, TOKEN_INITIAL_SUPPLY, deployerAddr)
 
     erc20 = await contract
   })
@@ -29,7 +27,7 @@ describe('ERC20', function () {
     symbol.should.be.equal(TOKEN_SYMBOL)
   })
   it('Should set the right initial supply', async function () {
-    const ownerBalance = Number(await erc20.methods.balanceOf(deployerF0Addr).call())
+    const ownerBalance = Number(await erc20.methods.balanceOf(deployerAddr).call())
 
     ownerBalance.should.be.equal(TOKEN_INITIAL_SUPPLY)
   })

--- a/test/web3.js/utils/deployContract.js
+++ b/test/web3.js/utils/deployContract.js
@@ -1,34 +1,38 @@
 const { artifacts, web3 } = require('hardhat')
 const { promisify } = require('util')
-const { getDeployerF1Address } = require('../../util/utils')
+const { getDeployerF1Address, isFilecoinNetwork } = require('../../util/utils')
+
+const sendRpcRequest = async (method, params) => {
+  return (await promisify(web3.currentProvider.send)({
+    method,
+    params,
+    jsonrpc: '2.0',
+    id: new Date().getTime(),
+  })).result
+}
 
 const deployContract = async (contractName, ...args) => {
-  const f1Addr = getDeployerF1Address()
+  const isFilecoin = await isFilecoinNetwork()
 
+  let options
   const from = (await web3.eth.getAccounts())[0]
-  const maxPriorityFeePerGas = (await promisify(web3.currentProvider.send)({
-    method: 'eth_maxPriorityFeePerGas',
-    params: [],
-    jsonrpc: '2.0',
-    id: new Date().getTime(),
-  })).result
-  const nonce = (await promisify(web3.currentProvider.send)({
-    method: 'Filecoin.MpoolGetNonce',
-    params: [f1Addr],
-    jsonrpc: '2.0',
-    id: new Date().getTime(),
-  })).result
+  if (isFilecoin) {
+    const f1Addr = getDeployerF1Address()
+    const nonce = await sendRpcRequest('Filecoin.MpoolGetNonce', [f1Addr])
+    const maxPriorityFeePerGas = await sendRpcRequest('eth_maxPriorityFeePerGas.MpoolGetNonce', [])
+    options = { from, nonce, maxPriorityFeePerGas, gasLimit: 1000000000 }
+  } else {
+    const nonce = await sendRpcRequest('Filecoin.MpoolGetNonce', [from])
+    options = { from, nonce }
+  }
 
   const { abi, bytecode } = await artifacts.readArtifact(contractName)
   const Contract = new web3.eth.Contract(abi)
   // send a deployment transaction, without waiting for the transaction to be mined
   return new Promise(function (resolve) {
-    const contract = Contract.deploy({ data: bytecode, arguments: args }).send({
-      from,
-      gasLimit: 1000000000,
-      maxPriorityFeePerGas,
-      nonce,
-    }).on('transactionHash', (txHash) => {
+    const contract = Contract.deploy({ data: bytecode, arguments: args })
+    .send(options)
+    .on('transactionHash', (txHash) => {
       resolve({ contract, txHash })
     })
   })

--- a/test/web3.js/utils/getDeployerAddresses.js
+++ b/test/web3.js/utils/getDeployerAddresses.js
@@ -1,6 +1,15 @@
 const { promisify } = require('util')
 const { web3 } = require('hardhat')
-const { actorIdToF0Address } = require('../../util/utils')
+const { actorIdToF0Address, isFilecoinNetwork, getDeployerF1Address } = require('../../util/utils')
+
+const getDeployerAddress = async () => {
+  if (await isFilecoinNetwork()) {
+    const deployerF1Addr = getDeployerF1Address()
+    return getDeployerF0Address(deployerF1Addr)
+  } else {
+    return (await web3.eth.getAccounts())[0]
+  }
+}
 
 const getDeployerF0Address = async (f1Addr) => {
   try {
@@ -21,5 +30,6 @@ const getDeployerF0Address = async (f1Addr) => {
 }
 
 module.exports = {
+  getDeployerAddress,
   getDeployerF0Address,
 }


### PR DESCRIPTION
## What this PR does

This PR treats the following pending item from the backlog:

- Add a small test to check if the connected node is part of a Filecoin network or not, so that we may run the Filecoin-specific parts only in this case, and have the whole project be compatible with other Ethereum networks (ganache,…) by default. This could help increase our confidence in the test suite.

All hardhat command can thus now be run with the `--network hardhat` option for instance to be run against a non-Filecoin EVM.